### PR TITLE
Suggest using lower case to describe magento objects.

### DIFF
--- a/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeBlockCommand.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeBlockCommand.php
@@ -56,7 +56,7 @@ class DescribeBlockCommand extends Command
 The block alias provided doesn't follow the Magento naming conventions.
 Please make sure it looks like the following:
 
-  Vendorname_Modulename/Blockname
+  vendorname_modulename/blockname
 
 The lowercase convention is used because it reflects the best practice
 convention within the Magento community. This reflects the identifier that

--- a/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeControllerCommand.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeControllerCommand.php
@@ -56,7 +56,7 @@ class DescribeControllerCommand extends Command
 The controller alias provided doesn't follow the Magento naming conventions.
 Please make sure it looks like the following:
 
-  Vendorname_Modulename/Blockname
+  vendorname_modulename/controllername
 
 The lowercase convention is used because it reflects the best practice
 convention within the Magento community. This reflects the identifier that

--- a/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeHelperCommand.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeHelperCommand.php
@@ -56,7 +56,7 @@ class DescribeHelperCommand extends Command
 The helper alias provided doesn't follow the Magento naming conventions.
 Please make sure it looks like the following:
 
-  Vendorname_Modulename/Blockname
+  vendorname_modulename/helpername
 
 The lowercase convention is used because it reflects the best practice
 convention within the Magento community. This reflects the identifier that

--- a/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeModelCommand.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeModelCommand.php
@@ -57,7 +57,7 @@ class DescribeModelCommand extends Command
 The model alias provided doesn't follow the Magento naming conventions.
 Please make sure it looks like the following:
 
-  Vendorname_Modulename/Blockname
+  vendorname_modulename/modelname
 
 The lowercase convention is used because it reflects the best practice
 convention within the Magento community. This reflects the identifier that

--- a/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeResourceModelCommand.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeResourceModelCommand.php
@@ -56,7 +56,7 @@ class DescribeResourceModelCommand extends Command
 The resource model alias provided doesn't follow the Magento naming conventions.
 Please make sure it looks like the following:
 
-  Vendorname_Modulename/Blockname
+  vendorname_modulename/resourcemodelname
 
 The lowercase convention is used because it reflects the best practice
 convention within the Magento community. This reflects the identifier that


### PR DESCRIPTION
We can allow uppercase for edge cases with legacy code, but the convention
is to use lowercase and magespec should suggest to use lowercase.
