### PR TITLE
Merged feature/code-pool-selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ mage_locator:
   spec_prefix: 'spec'
   src_path: 'public/app/code'
   spec_path: 'spec/public/app/code'
+  code_pool: 'community'
 ```
 
 Currently the mage_locator supports four options:
@@ -81,6 +82,7 @@ Currently the mage_locator supports four options:
 - spec_prefix (default 'spec'): The namespace prefix which will be used to namespace your specs based on your source code namespace
 - src_path (default 'src'): The relative path of your source code
 - spec_path (default '.'): The relative path of your specs
+- code_pool (default 'local'): Specifies the Magento code pool for creating the extension files. Options are 'local' and 'community'
 
 ### Describing a model
 

--- a/src/MageTest/PhpSpec/MagentoExtension/Autoloader/MageLoader.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Autoloader/MageLoader.php
@@ -40,13 +40,15 @@ class MageLoader
     protected $_collectPath         = null;
     protected $_arrLoadedClasses    = array();
     protected $_srcPath = '';
+    protected $_codePool = '';
 
     /**
      * Class constructor
      */
-    public function __construct($srcPath)
+    public function __construct($srcPath, $codePool)
     {
         $this->_srcPath = $srcPath;
+        $this->_codePool = $codePool;
         $this->_isIncludePathDefined = defined('COMPILER_INCLUDE_PATH');
         if (defined('COMPILER_COLLECT_PATH')) {
             $this->_collectClasses  = true;
@@ -60,10 +62,10 @@ class MageLoader
      *
      * @return Varien_Autoload
      */
-    static public function instance($srcPath)
+    static public function instance($srcPath, $codePool)
     {
         if (!self::$_instance) {
-            self::$_instance = new MageLoader($srcPath);
+            self::$_instance = new MageLoader($srcPath, $codePool);
         }
         return self::$_instance;
     }
@@ -71,9 +73,9 @@ class MageLoader
     /**
      * Register SPL autoload function
      */
-    static public function register($srcPath)
+    static public function register($srcPath, $codePool)
     {
-        spl_autoload_register(array(self::instance($srcPath), 'autoload'));
+        spl_autoload_register(array(self::instance($srcPath, $codePool), 'autoload'));
     }
 
     /**
@@ -186,7 +188,7 @@ class MageLoader
      */
     private function includeController($class)
     {
-        $local = $this->_srcPath . DIRECTORY_SEPARATOR . 'local' . DIRECTORY_SEPARATOR;
+        $local = $this->_srcPath . DIRECTORY_SEPARATOR . $this->_codePool . DIRECTORY_SEPARATOR;
         $controller = explode('_', $class);
         array_splice($controller, 2, 0 , 'controllers');
         $pathToController = implode(DIRECTORY_SEPARATOR, $controller);

--- a/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeModelCommand.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeModelCommand.php
@@ -44,8 +44,7 @@ class DescribeModelCommand extends Command
         $this
             ->setName('describe:model')
             ->setDescription('Describe a Magento Model specification')
-            ->addArgument('model_alias', InputArgument::REQUIRED, 'Magento Model alias to be described')
-            ->addOption('community', null, InputOption::VALUE_NONE, 'If set the specification will be created in the community code pool');
+            ->addArgument('model_alias', InputArgument::REQUIRED, 'Magento Model alias to be described');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/MageTest/PhpSpec/MagentoExtension/Extension.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Extension.php
@@ -158,6 +158,8 @@ class Extension implements ExtensionInterface
             $specPrefix = isset($suite['spec_prefix']) ? $suite['spec_prefix'] : '';
             $srcPath = isset($suite['src_path']) ? rtrim($suite['src_path'], '/') . DIRECTORY_SEPARATOR : 'src';
             $specPath = isset($suite['spec_path']) ? rtrim($suite['spec_path'], '/') . DIRECTORY_SEPARATOR : '.';
+            $codePool = isset($suite['code_pool']) ? $suite['code_pool'] : 'local';
+            $filesystem = null;
 
             if (!is_dir($srcPath)) {
                 mkdir($srcPath, 0777, true);
@@ -167,41 +169,41 @@ class Extension implements ExtensionInterface
             }
 
             $c->setShared('locator.locators.model_locator',
-                function ($c) use ($srcNS, $specPrefix, $srcPath, $specPath) {
-                    return new ModelLocator($srcNS, $specPrefix, $srcPath, $specPath);
+                function ($c) use ($srcNS, $specPrefix, $srcPath, $specPath, $filesystem, $codePool) {
+                    return new ModelLocator($srcNS, $specPrefix, $srcPath, $specPath, $filesystem, $codePool);
                 }
             );
 
             $c->setShared('locator.locators.resource_model_locator',
-                function ($c) use ($srcNS, $specPrefix, $srcPath, $specPath) {
-                    return new ResourceModelLocator($srcNS, $specPrefix, $srcPath, $specPath);
+                function ($c) use ($srcNS, $specPrefix, $srcPath, $specPath, $filesystem, $codePool) {
+                    return new ResourceModelLocator($srcNS, $specPrefix, $srcPath, $specPath, $filesystem, $codePool);
                 }
             );
 
             $c->setShared('locator.locators.block_locator',
-                function ($c) use ($srcNS, $specPrefix, $srcPath, $specPath) {
-                    return new BlockLocator($srcNS, $specPrefix, $srcPath, $specPath);
+                function ($c) use ($srcNS, $specPrefix, $srcPath, $specPath, $filesystem, $codePool) {
+                    return new BlockLocator($srcNS, $specPrefix, $srcPath, $specPath, $filesystem, $codePool);
                 }
             );
 
             $c->setShared('locator.locators.helper_locator',
-                function ($c) use ($srcNS, $specPrefix, $srcPath, $specPath) {
-                    return new HelperLocator($srcNS, $specPrefix, $srcPath, $specPath);
+                function ($c) use ($srcNS, $specPrefix, $srcPath, $specPath, $filesystem, $codePool) {
+                    return new HelperLocator($srcNS, $specPrefix, $srcPath, $specPath, $filesystem, $codePool);
                 }
             );
 
             $c->setShared('locator.locators.controller_locator',
-                function ($c) use ($srcNS, $specPrefix, $srcPath, $specPath) {
-                    return new ControllerLocator($srcNS, $specPrefix, $srcPath, $specPath);
+                function ($c) use ($srcNS, $specPrefix, $srcPath, $specPath, $filesystem, $codePool) {
+                    return new ControllerLocator($srcNS, $specPrefix, $srcPath, $specPath, $filesystem, $codePool);
                 }
             );
 
-            $extension->configureAutoloader($srcPath);
+            $extension->configureAutoloader($srcPath, $codePool);
         });
     }
 
-    public function configureAutoloader($srcPath)
+    public function configureAutoloader($srcPath, $codePool)
     {
-        MageLoader::register($srcPath);
+        MageLoader::register($srcPath, $codePool);
     }
 }

--- a/src/MageTest/PhpSpec/MagentoExtension/Locator/Magento/BlockLocator.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Locator/Magento/BlockLocator.php
@@ -48,14 +48,16 @@ class BlockLocator implements ResourceLocatorInterface
     private $fullSrcPath;
     private $fullSpecPath;
     private $filesystem;
+    private $codePool;
 
     public function __construct($srcNamespace = '', $specNamespacePrefix = '',
-                                $srcPath = 'src', $specPath = 'spec', Filesystem $filesystem = null)
+                                $srcPath = 'src', $specPath = 'spec', Filesystem $filesystem = null, $codePool = null)
     {
         $this->filesystem = $filesystem ? : new Filesystem;
+        $this->codePool   = $codePool ? : self::LOCAL_CODE_POOL;
 
-        $this->srcPath       = rtrim(realpath($srcPath), '/\\') . DIRECTORY_SEPARATOR . self::LOCAL_CODE_POOL . DIRECTORY_SEPARATOR;
-        $this->specPath      = rtrim(realpath($specPath), '/\\') . DIRECTORY_SEPARATOR . self::LOCAL_CODE_POOL . DIRECTORY_SEPARATOR;
+        $this->srcPath       = rtrim(realpath($srcPath), '/\\') . DIRECTORY_SEPARATOR . $this->codePool  . DIRECTORY_SEPARATOR;
+        $this->specPath      = rtrim(realpath($specPath), '/\\') . DIRECTORY_SEPARATOR . $this->codePool  . DIRECTORY_SEPARATOR;
         $this->srcNamespace  = ltrim(trim($srcNamespace, ' \\') . '\\', '\\');
         $this->specNamespace = trim($specNamespacePrefix, ' \\') . '\\';
         $this->fullSrcPath   = $this->srcPath;
@@ -94,6 +96,11 @@ class BlockLocator implements ResourceLocatorInterface
     public function getSpecNamespace()
     {
         return $this->specNamespace;
+    }
+
+    public function getCodePool()
+    {
+        return $this->codePool;
     }
 
     public function getAllResources()

--- a/src/MageTest/PhpSpec/MagentoExtension/Locator/Magento/ControllerLocator.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Locator/Magento/ControllerLocator.php
@@ -48,14 +48,17 @@ class ControllerLocator implements ResourceLocatorInterface
     private $fullSrcPath;
     private $fullSpecPath;
     private $filesystem;
+    private $codePool;
+
 
     public function __construct($srcNamespace = '', $specNamespacePrefix = '',
-                                $srcPath = 'src', $specPath = 'spec', Filesystem $filesystem = null)
+                                $srcPath = 'src', $specPath = 'spec', Filesystem $filesystem = null, $codePool = null)
     {
         $this->filesystem = $filesystem ? : new Filesystem;
+        $this->codePool   = $codePool ? : self::LOCAL_CODE_POOL;
 
-        $this->srcPath       = rtrim(realpath($srcPath), '/\\') . DIRECTORY_SEPARATOR . self::LOCAL_CODE_POOL . DIRECTORY_SEPARATOR;
-        $this->specPath      = rtrim(realpath($specPath), '/\\') . DIRECTORY_SEPARATOR . self::LOCAL_CODE_POOL . DIRECTORY_SEPARATOR;
+        $this->srcPath       = rtrim(realpath($srcPath), '/\\') . DIRECTORY_SEPARATOR . $this->codePool . DIRECTORY_SEPARATOR;
+        $this->specPath      = rtrim(realpath($specPath), '/\\') . DIRECTORY_SEPARATOR . $this->codePool . DIRECTORY_SEPARATOR;
         $this->srcNamespace  = ltrim(trim($srcNamespace, ' \\') . '\\', '\\');
         $this->specNamespace = trim($specNamespacePrefix, ' \\') . '\\';
         $this->fullSrcPath   = $this->srcPath;

--- a/src/MageTest/PhpSpec/MagentoExtension/Locator/Magento/HelperLocator.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Locator/Magento/HelperLocator.php
@@ -48,14 +48,16 @@ class HelperLocator implements ResourceLocatorInterface
     private $fullSrcPath;
     private $fullSpecPath;
     private $filesystem;
+    private $codePool;
 
     public function __construct($srcNamespace = '', $specNamespacePrefix = '',
-                                $srcPath = 'src', $specPath = 'spec', Filesystem $filesystem = null)
+                                $srcPath = 'src', $specPath = 'spec', Filesystem $filesystem = null, $codePool = null)
     {
         $this->filesystem = $filesystem ? : new Filesystem;
+        $this->codePool   = $codePool ? : self::LOCAL_CODE_POOL;
 
-        $this->srcPath       = rtrim(realpath($srcPath), '/\\') . DIRECTORY_SEPARATOR . self::LOCAL_CODE_POOL . DIRECTORY_SEPARATOR;
-        $this->specPath      = rtrim(realpath($specPath), '/\\') . DIRECTORY_SEPARATOR . self::LOCAL_CODE_POOL . DIRECTORY_SEPARATOR;
+        $this->srcPath       = rtrim(realpath($srcPath), '/\\') . DIRECTORY_SEPARATOR . $this->codePool . DIRECTORY_SEPARATOR;
+        $this->specPath      = rtrim(realpath($specPath), '/\\') . DIRECTORY_SEPARATOR . $this->codePool . DIRECTORY_SEPARATOR;
         $this->srcNamespace  = ltrim(trim($srcNamespace, ' \\') . '\\', '\\');
         $this->specNamespace = trim($specNamespacePrefix, ' \\') . '\\';
         $this->fullSrcPath   = $this->srcPath;

--- a/src/MageTest/PhpSpec/MagentoExtension/Locator/Magento/ModelLocator.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Locator/Magento/ModelLocator.php
@@ -48,14 +48,16 @@ class ModelLocator implements ResourceLocatorInterface
     private $fullSrcPath;
     private $fullSpecPath;
     private $filesystem;
+    private $codePool;
 
     public function __construct($srcNamespace = '', $specNamespacePrefix = '',
-                                $srcPath = 'src', $specPath = 'spec', Filesystem $filesystem = null)
+                                $srcPath = 'src', $specPath = 'spec', Filesystem $filesystem = null, $codePool = null)
     {
         $this->filesystem = $filesystem ? : new Filesystem;
+        $this->codePool   = $codePool ? : self::LOCAL_CODE_POOL;
 
-        $this->srcPath       = rtrim(realpath($srcPath), '/\\') . DIRECTORY_SEPARATOR . self::LOCAL_CODE_POOL . DIRECTORY_SEPARATOR;
-        $this->specPath      = rtrim(realpath($specPath), '/\\') . DIRECTORY_SEPARATOR . self::LOCAL_CODE_POOL . DIRECTORY_SEPARATOR;
+        $this->srcPath       = rtrim(realpath($srcPath), '/\\') . DIRECTORY_SEPARATOR . $this->codePool . DIRECTORY_SEPARATOR;
+        $this->specPath      = rtrim(realpath($specPath), '/\\') . DIRECTORY_SEPARATOR . $this->codePool . DIRECTORY_SEPARATOR;
         $this->srcNamespace  = ltrim(trim($srcNamespace, ' \\') . '\\', '\\');
         $this->specNamespace = trim($specNamespacePrefix, ' \\') . '\\';
         $this->fullSrcPath   = $this->srcPath;

--- a/src/MageTest/PhpSpec/MagentoExtension/Locator/Magento/ResourceModelLocator.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Locator/Magento/ResourceModelLocator.php
@@ -48,14 +48,16 @@ class ResourceModelLocator implements ResourceLocatorInterface
     private $fullSrcPath;
     private $fullSpecPath;
     private $filesystem;
+    private $codePool;
 
     public function __construct($srcNamespace = '', $specNamespacePrefix = '',
-                                $srcPath = 'src', $specPath = 'spec', Filesystem $filesystem = null)
+                                $srcPath = 'src', $specPath = 'spec', Filesystem $filesystem = null, $codePool = null)
     {
         $this->filesystem = $filesystem ? : new Filesystem;
+        $this->codePool   = $codePool ? : self::LOCAL_CODE_POOL;
 
-        $this->srcPath       = rtrim(realpath($srcPath), '/\\') . DIRECTORY_SEPARATOR . self::LOCAL_CODE_POOL . DIRECTORY_SEPARATOR;
-        $this->specPath      = rtrim(realpath($specPath), '/\\') . DIRECTORY_SEPARATOR . self::LOCAL_CODE_POOL . DIRECTORY_SEPARATOR;
+        $this->srcPath       = rtrim(realpath($srcPath), '/\\') . DIRECTORY_SEPARATOR . $this->codePool . DIRECTORY_SEPARATOR;
+        $this->specPath      = rtrim(realpath($specPath), '/\\') . DIRECTORY_SEPARATOR . $this->codePool . DIRECTORY_SEPARATOR;
         $this->srcNamespace  = ltrim(trim($srcNamespace, ' \\') . '\\', '\\');
         $this->specNamespace = trim($specNamespacePrefix, ' \\') . '\\';
         $this->fullSrcPath   = $this->srcPath;


### PR DESCRIPTION
Adds functionality for supporting the community code pool, this can be controller by adding a new codepool parameter to the phpspec.yml like so:

```
extensions: [MageTest\PhpSpec\MagentoExtension\Extension]
mage_locator:
  spec_prefix: 'spec'
  src_path: 'public/app/code'
  spec_path: 'spec/public/app/code'
  code_pool: 'community'
```

Code generation and autoloading are working properly. Any instances of the hardcoded local codepool have been replaced with the matching variables and all the generators and locators have been updated.

I'm open to discuss the changes if there are any questions.
