### PR TITLE
Generate module and config XML when objects are created

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "require": {
         "phpspec/phpspec": "~2.0",
         "symfony/dependency-injection": "*",
-        "symfony/config": "*"
+        "symfony/config": "*",
+        "shanethehat/pretty-xml": "0.2.1"
     },
     "require-dev": {
         "magetest/magento": "~1.8.1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cdcf6fe02b169defb4c477cf21c43351",
+    "hash": "b9fe8728cb9d764ece4d7093ffeddbb8",
     "packages": [
         {
             "name": "phpspec/php-diff",
@@ -166,6 +166,48 @@
                 "stub"
             ],
             "time": "2014-01-24 11:03:43"
+        },
+        {
+            "name": "shanethehat/pretty-xml",
+            "version": "0.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/shanethehat/pretty-xml.git",
+                "reference": "8bc045958861b16f1bff07a642e4884582a3d107"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/shanethehat/pretty-xml/zipball/8bc045958861b16f1bff07a642e4884582a3d107",
+                "reference": "8bc045958861b16f1bff07a642e4884582a3d107",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpspec/phpspec": "~2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PrettyXml": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Shane Auckland",
+                    "email": "shane.auckland@gmail.com",
+                    "homepage": "http://shaneauckland.co.uk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for pretty-printing XML",
+            "keywords": [
+                "pretty",
+                "xml"
+            ],
+            "time": "2014-07-18 21:53:11"
         },
         {
             "name": "symfony/config",

--- a/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/ConfigGeneratorSpec.php
+++ b/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/ConfigGeneratorSpec.php
@@ -1,0 +1,365 @@
+<?php
+
+namespace spec\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml;
+
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element\BlockElement;
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element\ControllerElement;
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element\HelperElement;
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element\ModelElement;
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element\ResourceModelElement;
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element\SimpleElement;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Util\Filesystem;
+use PrettyXml\Formatter;
+use Prophecy\Argument;
+
+class ConfigGeneratorSpec extends ObjectBehavior
+{
+    private $path = 'public/app/code/';
+
+    function let(Filesystem $fileSystem, Formatter $formatter)
+    {
+        $this->beConstructedWith($this->path, $fileSystem, $formatter);
+        $this->path .= 'local/';
+    }
+
+    function it_does_not_create_a_block_element_when_one_exists($fileSystem)
+    {
+        $fileSystem->pathExists($this->path . 'Vendor/Module/etc/config.xml')->willReturn(true);
+        $fileSystem->getFileContents($this->path . 'Vendor/Module/etc/config.xml')
+            ->willReturn($this->getBlockXmlStructure());
+        $fileSystem->putFileContents(Argument::any())->shouldNotBeCalled();
+        $this->addElementGenerator(new BlockElement());
+        $this->generateElement('block', 'Vendor_Module');
+
+    }
+
+    function it_creates_the_etc_directory_if_it_does_not_exist($fileSystem, $formatter)
+    {
+        $fileSystem->isDirectory($this->path . 'Vendor/Module/etc/')->willReturn(false);
+        $fileSystem->makeDirectory($this->path . 'Vendor/Module/etc/')->shouldBeCalled();
+        $fileSystem->pathExists($this->path . 'Vendor/Module/etc/config.xml')->willReturn(false);
+        $fileSystem->getFileContents(Argument::any())->shouldNotBeCalled();
+        $formatter->format(Argument::containingString(
+            '<blocks><vendor_module><class>Vendor_Module_Block</class></vendor_module></blocks>'
+        ))->willReturn($this->getBlockXmlStructure());
+        $fileSystem->putFileContents(
+            $this->path . 'Vendor/Module/etc/config.xml',
+            $this->getBlockXmlStructure()
+        )->shouldBeCalled();
+        $this->addElementGenerator(new BlockElement());
+        $this->generateElement('block', 'Vendor_Module');
+    }
+
+    function it_generates_a_block_element_when_the_config_file_does_not_exist($fileSystem, $formatter)
+    {
+        $fileSystem->isDirectory($this->path . 'Vendor/Module/etc/')->willReturn(true);
+        $fileSystem->pathExists($this->path . 'Vendor/Module/etc/config.xml')->willReturn(false);
+        $fileSystem->getFileContents(Argument::any())->shouldNotBeCalled();
+        $formatter->format(Argument::containingString(
+            '<blocks><vendor_module><class>Vendor_Module_Block</class></vendor_module></blocks>'
+        ))->willReturn($this->getBlockXmlStructure());
+        $fileSystem->putFileContents(
+            $this->path . 'Vendor/Module/etc/config.xml',
+            $this->getBlockXmlStructure()
+        )->shouldBeCalled();
+        $this->addElementGenerator(new BlockElement());
+        $this->generateElement('block', 'Vendor_Module');
+    }
+
+    function it_generates_a_block_element($fileSystem, $formatter)
+    {
+        $fileSystem->isDirectory($this->path . 'Vendor/Module/etc/')->willReturn(true);
+        $fileSystem->pathExists($this->path . 'Vendor/Module/etc/config.xml')->willReturn(true);
+        $fileSystem->getFileContents($this->path . 'Vendor/Module/etc/config.xml')
+            ->willReturn($this->getPlainXmlStructure());
+        $formatter->format(Argument::containingString(
+            '<blocks><vendor_module><class>Vendor_Module_Block</class></vendor_module></blocks>'
+        ))->willReturn($this->getBlockXmlStructure());
+        $fileSystem->putFileContents(
+            $this->path . 'Vendor/Module/etc/config.xml',
+            $this->getBlockXmlStructure()
+        )->shouldBeCalled();
+        $this->addElementGenerator(new BlockElement());
+        $this->generateElement('block', 'Vendor_Module');
+    }
+
+    function it_generates_a_block_element_when_multiple_element_generators_are_added($fileSystem, $formatter)
+    {
+        $fileSystem->isDirectory($this->path . 'Vendor/Module/etc/')->willReturn(true);
+        $fileSystem->pathExists($this->path . 'Vendor/Module/etc/config.xml')->willReturn(true);
+        $fileSystem->getFileContents($this->path . 'Vendor/Module/etc/config.xml')
+            ->willReturn($this->getPlainXmlStructure());
+        $formatter->format(Argument::containingString(
+            '<blocks><vendor_module><class>Vendor_Module_Block</class></vendor_module></blocks>'
+        ))->willReturn($this->getBlockXmlStructure());
+        $fileSystem->putFileContents(
+            $this->path . 'Vendor/Module/etc/config.xml',
+            $this->getBlockXmlStructure()
+        )->shouldBeCalled();
+        $this->addElementGenerator(new ControllerElement());
+        $this->addElementGenerator(new BlockElement());
+        $this->addElementGenerator(new HelperElement());
+        $this->generateElement('block', 'Vendor_Module');
+    }
+
+    function it_generates_a_model_element($fileSystem, $formatter)
+    {
+        $fileSystem->isDirectory($this->path . 'Vendor/Module/etc/')->willReturn(true);
+        $fileSystem->pathExists($this->path . 'Vendor/Module/etc/config.xml')->willReturn(true);
+        $fileSystem->getFileContents($this->path . 'Vendor/Module/etc/config.xml')
+            ->willReturn($this->getPlainXmlStructure());
+        $formatter->format(Argument::containingString(
+            '<models><vendor_module><class>Vendor_Module_Model</class></vendor_module></models>'
+        ))->willReturn($this->getModelXmlStructure());
+        $fileSystem->putFileContents(
+            $this->path . 'Vendor/Module/etc/config.xml',
+            $this->getModelXmlStructure()
+        )->shouldBeCalled();
+        $this->addElementGenerator(new ModelElement());
+        $this->generateElement('model', 'Vendor_Module');
+    }
+
+    function it_generates_a_helper_element($fileSystem, $formatter)
+    {
+        $fileSystem->isDirectory($this->path . 'Vendor/Module/etc/')->willReturn(true);
+        $fileSystem->pathExists($this->path . 'Vendor/Module/etc/config.xml')->willReturn(true);
+        $fileSystem->getFileContents($this->path . 'Vendor/Module/etc/config.xml')
+            ->willReturn($this->getPlainXmlStructure());
+        $formatter->format(Argument::containingString(
+            '<helpers><vendor_module><class>Vendor_Module_Helper</class></vendor_module></helpers>'
+        ))->willReturn($this->getHelperXmlStructure());
+        $fileSystem->putFileContents(
+            $this->path . 'Vendor/Module/etc/config.xml',
+            $this->getHelperXmlStructure()
+        )->shouldBeCalled();
+        $this->addElementGenerator(new HelperElement());
+        $this->generateElement('helper', 'Vendor_Module');
+    }
+
+    function it_generates_a_resource_model_element($fileSystem, $formatter)
+    {
+        $fileSystem->isDirectory($this->path . 'Vendor/Module/etc/')->willReturn(true);
+        $fileSystem->pathExists($this->path . 'Vendor/Module/etc/config.xml')->willReturn(true);
+        $fileSystem->getFileContents($this->path . 'Vendor/Module/etc/config.xml')
+            ->willReturn($this->getPlainXmlStructure());
+        $formatter->format(Argument::containingString(
+            '<models><vendor_module_resource><class>Vendor_Module_Model_Resource</class></vendor_module_resource></models>'
+        ))->willReturn($this->getResourceModelXmlStructure());
+        $fileSystem->putFileContents(
+            $this->path . 'Vendor/Module/etc/config.xml',
+            $this->getResourceModelXmlStructure()
+        )->shouldBeCalled();
+
+        $this->addElementGenerator(new ResourceModelElement());
+        $this->generateElement('resource_model', 'Vendor_Module');
+    }
+
+    function it_generates_a_resource_model_when_a_model_element_exists($fileSystem, $formatter)
+    {
+        $fileSystem->isDirectory($this->path . 'Vendor/Module/etc/')->willReturn(true);
+        $fileSystem->pathExists($this->path . 'Vendor/Module/etc/config.xml')->willReturn(true);
+        $fileSystem->getFileContents($this->path . 'Vendor/Module/etc/config.xml')
+            ->willReturn($this->getModelXmlStructure());
+        $formatter->format(Argument::that(function ($arg) {
+            return strpos($arg, '<resourceModel>vendor_module_resource</resourceModel>')
+                && strpos($arg, '<vendor_module_resource><class>Vendor_Module_Model_Resource</class></vendor_module_resource>');
+        }))->willReturn($this->getModelResourceModelXmlStructure());
+        $fileSystem->putFileContents(
+            $this->path . 'Vendor/Module/etc/config.xml',
+            $this->getModelResourceModelXmlStructure()
+        )->shouldBeCalled();
+
+        $this->addElementGenerator(new ResourceModelElement());
+        $this->generateElement('resource_model', 'Vendor_Module');
+    }
+
+    function it_generates_a_model_when_a_resource_model_element_exists($fileSystem, $formatter)
+    {
+        $fileSystem->isDirectory($this->path . 'Vendor/Module/etc/')->willReturn(true);
+        $fileSystem->pathExists($this->path . 'Vendor/Module/etc/config.xml')->willReturn(true);
+        $fileSystem->getFileContents($this->path . 'Vendor/Module/etc/config.xml')
+            ->willReturn($this->getResourceModelXmlStructure());
+        $formatter->format(Argument::that(function ($arg) {
+            return strpos($arg, '<resourceModel>vendor_module_resource</resourceModel>')
+            && strpos($arg, '<class>Vendor_Module_Model_Resource</class>');
+        }))->willReturn($this->getModelResourceModelXmlStructure());
+        $fileSystem->putFileContents(
+            $this->path . 'Vendor/Module/etc/config.xml',
+            $this->getModelResourceModelXmlStructure()
+        )->shouldBeCalled();
+
+        $this->addElementGenerator(new ModelElement());
+        $this->generateElement('model', 'Vendor_Module');
+    }
+
+    function it_generates_a_controller_element($fileSystem, $formatter)
+    {
+        $fileSystem->isDirectory($this->path . 'Vendor/Module/etc/')->willReturn(true);
+        $fileSystem->pathExists($this->path . 'Vendor/Module/etc/config.xml')->willReturn(true);
+        $fileSystem->getFileContents($this->path . 'Vendor/Module/etc/config.xml')
+            ->willReturn($this->getPlainXmlStructure());
+        $formatter->format(Argument::containingString(
+            '<frontend><routers><module><use>standard</use><args><module>Vendor_Module</module><frontName>module</frontName></args></module></routers></frontend>'
+        ))->willReturn($this->getControllerXmlStructure());
+        $fileSystem->putFileContents(
+            $this->path . 'Vendor/Module/etc/config.xml',
+            $this->getControllerXmlStructure()
+        )->shouldBeCalled();
+
+        $this->addElementGenerator(new ControllerElement());
+        $this->generateElement('controller', 'Vendor_Module');
+    }
+
+    private function getPlainXmlStructure()
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <modules>
+        <Vendor_Module>
+            <version>0.1.0</version>
+        </Vendor_Module>
+    </modules>
+    <global>
+    </global>
+</config>
+XML;
+    }
+
+    private function getBlockXmlStructure()
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <modules>
+        <Vendor_Module>
+            <version>0.1.0</version>
+        </Vendor_Module>
+    </modules>
+    <global>
+        <blocks>
+            <vendor_module>
+                <class>Vendor_Module_Block</class>
+            </vendor_module>
+        </blocks>
+    </global>
+</config>
+XML;
+    }
+
+    private function getModelXmlStructure()
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <modules>
+        <Vendor_Module>
+            <version>0.1.0</version>
+        </Vendor_Module>
+    </modules>
+    <global>
+        <models>
+            <vendor_module>
+                <class>Vendor_Module_Model</class>
+            </vendor_module>
+        </models>
+    </global>
+</config>
+XML;
+    }
+
+    private function getModelResourceModelXmlStructure()
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <modules>
+        <Vendor_Module>
+            <version>0.1.0</version>
+        </Vendor_Module>
+    </modules>
+    <global>
+        <models>
+            <vendor_module>
+                <class>Vendor_Module_Model</class>
+                <resourceModel>vendor_model_resource</resourceModel>
+            </vendor_module>
+            <vendor_module_resource>
+                <class>Vendor_Module_Model_Resource</class>
+            </vendor_module_resource>
+        </models>
+    </global>
+</config>
+XML;
+    }
+
+    private function getResourceModelXmlStructure()
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <modules>
+        <Vendor_Module>
+            <version>0.1.0</version>
+        </Vendor_Module>
+    </modules>
+    <global>
+        <models>
+            <vendor_module_resource>
+                <class>Vendor_Module_Model_Resource</class>
+            </vendor_module_resource>
+        </models>
+    </global>
+</config>
+XML;
+    }
+
+    private function getHelperXmlStructure()
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <modules>
+        <Vendor_Module>
+            <version>0.1.0</version>
+        </Vendor_Module>
+    </modules>
+    <global>
+        <helpers>
+            <vendor_module>
+                <class>Vendor_Module_Helper</class>
+            </vendor_module>
+        </helpers>
+    </global>
+</config>
+XML;
+    }
+
+    private function getControllerXMLStructure()
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <modules>
+        <Vendor_Module>
+            <version>0.1.0</version>
+        </Vendor_Module>
+    </modules>
+    <global>
+    </global>
+    <frontend>
+        <routers>
+            <module>
+                <use>standard</use>
+                <args>
+                    <module>Vendor_Module</module>
+                    <frontName>module</frontName>
+                </args>
+            </module>
+        </routers>
+    </frontend>
+</config>
+XML;
+    }
+}

--- a/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/BlockElementSpec.php
+++ b/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/BlockElementSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace spec\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class BlockElementSpec extends ObjectBehavior
+{
+    function it_is_a_config_element()
+    {
+        $this->shouldImplement(
+            'MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element\ConfigElementInterface'
+        );
+    }
+
+    function it_should_support_the_block_element()
+    {
+        $this->supports('block')->shouldReturn(true);
+    }
+}

--- a/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ControllerElementSpec.php
+++ b/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ControllerElementSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace spec\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ControllerElementSpec extends ObjectBehavior
+{
+    function it_is_a_config_element()
+    {
+        $this->shouldImplement(
+            'MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element\ConfigElementInterface'
+        );
+    }
+
+    function it_should_support_the_controller_element()
+    {
+        $this->supports('controller')->shouldReturn(true);
+    }
+}

--- a/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/HelperElementSpec.php
+++ b/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/HelperElementSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace spec\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class HelperElementSpec extends ObjectBehavior
+{
+    function it_is_a_config_element()
+    {
+        $this->shouldImplement(
+            'MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element\ConfigElementInterface'
+        );
+    }
+
+    function it_should_support_the_helper_element()
+    {
+        $this->supports('helper')->shouldReturn(true);
+    }
+}

--- a/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ModelElementSpec.php
+++ b/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ModelElementSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace spec\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ModelElementSpec extends ObjectBehavior
+{
+    function it_is_a_config_element()
+    {
+        $this->shouldImplement(
+            'MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element\ConfigElementInterface'
+        );
+    }
+
+    function it_should_support_the_model_element()
+    {
+        $this->supports('model')->shouldReturn(true);
+    }
+}

--- a/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ResourceModelElementSpec.php
+++ b/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ResourceModelElementSpec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace spec\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ResourceModelElementSpec extends ObjectBehavior
+{
+    function it_is_a_config_element()
+    {
+        $this->shouldImplement(
+            'MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element\ConfigElementInterface'
+        );
+    }
+
+    function it_should_support_the_model_element()
+    {
+        $this->supports('resource_model')->shouldReturn(true);
+    }
+}

--- a/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/ModuleGeneratorSpec.php
+++ b/spec/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/ModuleGeneratorSpec.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace spec\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml;
+
+use PhpSpec\Locator\ResourceInterface;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Util\Filesystem;
+use Prophecy\Argument;
+
+class ModuleGeneratorSpec extends ObjectBehavior
+{
+    private $path = 'public/app/etc/modules/';
+
+    function let(Filesystem $fileSystem)
+    {
+        $this->beConstructedWith($this->path, $fileSystem);
+    }
+
+    function it_generates_the_module_xml_file_if_one_does_not_exist($fileSystem)
+    {
+        $fileSystem->pathExists('public/app/etc/modules/Vendor_Module.xml')->willReturn(false);
+        $fileSystem->putFileContents(
+            $this->path . 'Vendor_Module.xml',
+            <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <modules>
+        <Vendor_Module>
+            <active>true</active>
+            <codePool>local</codePool>
+        </Vendor_Module>
+    </modules>
+</config>
+XML
+        )->shouldBeCalled();
+        $this->generate('Vendor_Module');
+    }
+
+
+    function it_generates_the_module_xml_file_in_a_different_code_pool($fileSystem)
+    {
+        $this->beConstructedWith($this->path, $fileSystem, 'community');
+        $fileSystem->pathExists('public/app/etc/modules/Vendor_Module.xml')->willReturn(false);
+        $fileSystem->putFileContents(
+            $this->path . 'Vendor_Module.xml',
+            <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <modules>
+        <Vendor_Module>
+            <active>true</active>
+            <codePool>community</codePool>
+        </Vendor_Module>
+    </modules>
+</config>
+XML
+        )->shouldBeCalled();
+        $this->generate('Vendor_Module');
+    }
+
+    function it_does_not_generate_the_module_xml_file_if_one_already_exists($fileSystem)
+    {
+        $fileSystem->pathExists('public/app/etc/modules/Vendor_Module.xml')->willReturn(true);
+        $fileSystem->putFileContents(Argument::any())->shouldNotBeCalled();
+        $this->generate('Vendor_Module');
+    }
+}

--- a/spec/MageTest/PhpSpec/MagentoExtension/ExtensionSpec.php
+++ b/spec/MageTest/PhpSpec/MagentoExtension/ExtensionSpec.php
@@ -26,6 +26,7 @@ use PhpSpec\ServiceContainer;
 use PhpSpec\Console\IO;
 use PhpSpec\CodeGenerator\TemplateRenderer;
 use PhpSpec\Formatter\Presenter\PresenterInterface;
+use PhpSpec\Util\Filesystem;
 use PhpSpec\Wrapper\Unwrapper;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -59,10 +60,11 @@ class ExtensionSpec extends ObjectBehavior
         $this->load($container);
     }
 
-    function it_registers_a_mage_model_code_generator_when_loaded($container, IO $console, TemplateRenderer $templateRenderer)
+    function it_registers_a_mage_model_code_generator_when_loaded($container, IO $console, TemplateRenderer $templateRenderer, Filesystem $filesystem)
     {
         $container->get('console.io')->willReturn($console);
         $container->get('code_generator.templates')->willReturn($templateRenderer);
+        $container->get('filesystem')->willReturn($filesystem);
 
         $container->setShared('code_generator.generators.mage_model', $this->service('\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\ModelGenerator', $container))->shouldBeCalled();
 
@@ -76,10 +78,11 @@ class ExtensionSpec extends ObjectBehavior
         $this->load($container);
     }
 
-    function it_registers_a_mage_resource_model_code_generator_when_loaded($container, IO $console, TemplateRenderer $templateRenderer)
+    function it_registers_a_mage_resource_model_code_generator_when_loaded($container, IO $console, TemplateRenderer $templateRenderer, Filesystem $filesystem)
     {
         $container->get('console.io')->willReturn($console);
         $container->get('code_generator.templates')->willReturn($templateRenderer);
+        $container->get('filesystem')->willReturn($filesystem);
 
         $container->setShared('code_generator.generators.mage_resource_model', $this->service('\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\ResourceModelGenerator', $container))->shouldBeCalled();
 
@@ -93,10 +96,11 @@ class ExtensionSpec extends ObjectBehavior
         $this->load($container);
     }
 
-    function it_registers_a_mage_block_code_generator_when_loaded($container, IO $console, TemplateRenderer $templateRenderer)
+    function it_registers_a_mage_block_code_generator_when_loaded($container, IO $console, TemplateRenderer $templateRenderer, Filesystem $filesystem)
     {
         $container->get('console.io')->willReturn($console);
         $container->get('code_generator.templates')->willReturn($templateRenderer);
+        $container->get('filesystem')->willReturn($filesystem);
 
         $container->setShared('code_generator.generators.mage_block', $this->service('\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\BlockGenerator', $container))->shouldBeCalled();
 
@@ -110,10 +114,11 @@ class ExtensionSpec extends ObjectBehavior
         $this->load($container);
     }
 
-    function it_registers_a_mage_helper_code_generator_when_loaded($container, IO $console, TemplateRenderer $templateRenderer)
+    function it_registers_a_mage_helper_code_generator_when_loaded($container, IO $console, TemplateRenderer $templateRenderer, Filesystem $filesystem)
     {
         $container->get('console.io')->willReturn($console);
         $container->get('code_generator.templates')->willReturn($templateRenderer);
+        $container->get('filesystem')->willReturn($filesystem);
 
         $container->setShared('code_generator.generators.mage_helper', $this->service('\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\HelperGenerator', $container))->shouldBeCalled();
 
@@ -127,20 +132,22 @@ class ExtensionSpec extends ObjectBehavior
         $this->load($container);
     }
 
-    function it_registers_a_mage_controller_code_generator_when_loaded($container, IO $console, TemplateRenderer $templateRenderer)
+    function it_registers_a_mage_controller_code_generator_when_loaded($container, IO $console, TemplateRenderer $templateRenderer, Filesystem $filesystem)
     {
         $container->get('console.io')->willReturn($console);
         $container->get('code_generator.templates')->willReturn($templateRenderer);
+        $container->get('filesystem')->willReturn($filesystem);
 
         $container->setShared('code_generator.generators.mage_controller', $this->service('\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\ControllerGenerator', $container))->shouldBeCalled();
 
         $this->load($container);
     }
 
-    function it_registers_a_mage_controller_specification_generator_when_loaded($container, IO $console, TemplateRenderer $templateRenderer)
+    function it_registers_a_mage_controller_specification_generator_when_loaded($container, IO $console, TemplateRenderer $templateRenderer, Filesystem $filesystem)
     {
         $container->get('console.io')->willReturn($console);
         $container->get('code_generator.templates')->willReturn($templateRenderer);
+        $container->get('filesystem')->willReturn($filesystem);
 
         $container->setShared('code_generator.generators.controller_specification', $this->service('\MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\ControllerSpecificationGenerator', $container))->shouldBeCalled();
 

--- a/spec/MageTest/PhpSpec/MagentoExtension/Listener/ModuleUpdateListenerSpec.php
+++ b/spec/MageTest/PhpSpec/MagentoExtension/Listener/ModuleUpdateListenerSpec.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace spec\MageTest\PhpSpec\MagentoExtension\Listener;
+
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\ConfigGenerator;
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\ModuleGenerator;
+use MageTest\PhpSpec\MagentoExtension\Util\ClassDetector;
+use PhpSpec\Console\IO;
+use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Event\SuiteEvent;
+use PhpSpec\Exception\Fracture\ClassNotFoundException;
+use PhpSpec\Locator\ResourceInterface;
+use PhpSpec\ObjectBehavior;
+use PhpSpec\Util\Filesystem;
+use Prophecy\Argument;
+
+class ModuleUpdateListenerSpec extends ObjectBehavior
+{
+    function let(ModuleGenerator $moduleGenerator, ConfigGenerator $configGenerator, IO $io, ClassDetector $detector)
+    {
+        $io->isCodeGenerationEnabled()->willReturn(true);
+        $detector->classExists(Argument::any())->willReturn(true);
+        $this->beConstructedWith($moduleGenerator, $configGenerator, $io, $detector);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldHaveType('Symfony\Component\EventDispatcher\EventSubscriberInterface');
+    }
+
+    function it_extracts_class_names_from_event_exceptions(ExampleEvent $event, ClassNotFoundException $exception)
+    {
+        $event->getException()->willReturn($exception);
+
+        $this->getClassNameAfterExample($event);
+
+        $exception->getClassname()->shouldHaveBeenCalled();
+    }
+
+    function it_generates_a_module_xml(
+        ExampleEvent $exampleEvent, ClassNotFoundException $exception, SuiteEvent $suiteEvent, $moduleGenerator
+    ){
+        $exampleEvent->getException()->willReturn($exception);
+        $exception->getClassname()->willReturn('Vendor_Module_Model_Foo');
+        $this->getClassNameAfterExample($exampleEvent);
+
+        $this->createXmlAfterSuite($suiteEvent);
+
+        $moduleGenerator->generate('Vendor_Module')->shouldHavebeenCalled();
+    }
+
+    function it_does_not_generate_a_module_xml_if_code_generation_is_disabled(
+        ExampleEvent $exampleEvent, ClassNotFoundException $exception, SuiteEvent $suiteEvent, $moduleGenerator, $io
+    ) {
+        $exampleEvent->getException()->willReturn($exception);
+        $exception->getClassname()->willReturn('Vendor_Module_Model_Foo');
+        $this->getClassNameAfterExample($exampleEvent);
+
+        $io->isCodeGenerationEnabled()->willReturn(false);
+
+        $moduleGenerator->moduleFileExists('Vendor_Module')->shouldNotBeCalled();
+        $moduleGenerator->generate('Vendor_Module')->shouldNotBeCalled();
+
+        $this->createXmlAfterSuite($suiteEvent);
+    }
+
+    function it_does_not_generate_a_module_xml_if_the_class_does_not_exist(
+        ExampleEvent $exampleEvent, ClassNotFoundException $exception, SuiteEvent $suiteEvent, $moduleGenerator, $detector
+    ) {
+        $exampleEvent->getException()->willReturn($exception);
+        $exception->getClassname()->willReturn('Vendor_Module_Model_Foo');
+        $this->getClassNameAfterExample($exampleEvent);
+
+        $detector->classExists('Vendor_Module_Model_Foo')->willReturn(false);
+
+        $moduleGenerator->moduleFileExists('Vendor_Module')->shouldNotBeCalled();
+        $moduleGenerator->generate('Vendor_Module')->shouldNotBeCalled();
+
+        $this->createXmlAfterSuite($suiteEvent);
+    }
+
+    function it_generates_a_config_xml(
+        ExampleEvent $exampleEvent, ClassNotFoundException $exception, SuiteEvent $suiteEvent, $configGenerator
+    ){
+        $exampleEvent->getException()->willReturn($exception);
+        $exception->getClassname()->willReturn('Vendor_Module_Model_Foo');
+        $this->getClassNameAfterExample($exampleEvent);
+
+        $this->createXmlAfterSuite($suiteEvent);
+
+        $configGenerator->generateElement('model', 'Vendor_Module')->shouldHavebeenCalled();
+    }
+
+    function it_identifies_a_resource_model_type(
+        ExampleEvent $exampleEvent, ClassNotFoundException $exception, SuiteEvent $suiteEvent, $configGenerator
+    ) {
+        $exampleEvent->getException()->willReturn($exception);
+        $exception->getClassname()->willReturn('Vendor_Module_Model_Resource_Foo');
+        $this->getClassNameAfterExample($exampleEvent);
+
+        $this->createXmlAfterSuite($suiteEvent);
+
+        $configGenerator->generateElement('resource_model', 'Vendor_Module')->shouldHavebeenCalled();
+    }
+}

--- a/src/MageTest/PhpSpec/MagentoExtension/Autoloader/MageLoader.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Autoloader/MageLoader.php
@@ -45,7 +45,7 @@ class MageLoader
     /**
      * Class constructor
      */
-    public function __construct($srcPath, $codePool)
+    public function __construct($srcPath, $codePool = 'local')
     {
         $this->_srcPath = $srcPath;
         $this->_codePool = $codePool;
@@ -54,6 +54,7 @@ class MageLoader
             $this->_collectClasses  = true;
             $this->_collectPath     = COMPILER_COLLECT_PATH;
         }
+        set_include_path(get_include_path() . PATH_SEPARATOR . $this->_srcPath . $this->_codePool);
         self::registerScope(self::$_scope);
     }
 

--- a/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/ConfigGenerator.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/ConfigGenerator.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml;
+
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element\ConfigElementInterface;
+use PhpSpec\Util\Filesystem;
+use PrettyXml\Formatter;
+
+class ConfigGenerator
+{
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var Formatter
+     */
+    private $formatter;
+
+    /**
+     * @var string
+     */
+    private $directory;
+
+    /**
+     * @var array
+     */
+    private $elementGenerators = array();
+
+    public function __construct($path, Filesystem $filesystem, Formatter $formatter, $codePool = 'local')
+    {
+        $this->path = $path . $codePool . DIRECTORY_SEPARATOR;
+        $this->filesystem = $filesystem;
+        $this->formatter = $formatter;
+    }
+
+    public function addElementGenerator(ConfigElementInterface $elementGenerator)
+    {
+        $this->elementGenerators[] = $elementGenerator;
+    }
+
+    public function generateElement($type, $moduleName)
+    {
+        $this->directory = $this->getDirectoryPath($moduleName);
+
+        $xml = new \SimpleXMLElement($this->getCurrentConfigXml($moduleName));
+
+        foreach ($this->elementGenerators as $elementGenerator) {
+            if ($elementGenerator->supports($type)) {
+                if ($elementGenerator->elementExistsInXml($xml, $type, $moduleName)) {
+                    return;
+                }
+                $elementGenerator->addElementToXml($xml, $type, $moduleName);
+                $formatted = $this->getIndentedXml($xml);
+                $this->writeConfigFile($formatted);
+                return;
+            }
+        }
+
+        throw new XmlGeneratorException('No element generator found for type: '.$type);
+    }
+
+    private function getDirectoryPath($moduleName)
+    {
+        $modulePath = str_replace('_', DIRECTORY_SEPARATOR, $moduleName);
+        return $this->path . $modulePath . DIRECTORY_SEPARATOR . 'etc' . DIRECTORY_SEPARATOR;
+    }
+
+    private function getCurrentConfigXml($moduleName)
+    {
+        if (!$this->moduleFileExists($moduleName)) {
+            $values = array(
+                '%module_name%' => $moduleName
+            );
+            return strtr(file_get_contents(__FILE__, null, null, __COMPILER_HALT_OFFSET__), $values);
+        }
+        return $this->filesystem->getFileContents($this->getFilePath());
+    }
+
+    private function getFilePath()
+    {
+        return $this->directory . 'config.xml';
+    }
+
+    private function moduleFileExists()
+    {
+        return $this->filesystem->pathExists($this->getFilePath());
+    }
+
+    private function getIndentedXml(\SimpleXMLElement $xml)
+    {
+        return $this->formatter->format($xml->asXML());
+    }
+
+    private function writeConfigFile($xml)
+    {
+        if (!$this->filesystem->isDirectory($this->directory)) {
+            $this->filesystem->makeDirectory($this->directory);
+        }
+        $this->filesystem->putFileContents($this->getFilePath(), $xml);
+    }
+}
+__halt_compiler();<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <modules>
+        <%module_name%>
+            <version>0.1.0</version>
+        </%module_name%>
+    </modules>
+    <global>
+    </global>
+</config>

--- a/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/BlockElement.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/BlockElement.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element;
+
+class BlockElement extends SimpleElementAbstract implements ConfigElementInterface
+{
+    /**
+     * @param string $type
+     * @return boolean
+     */
+    public function supports($type)
+    {
+        return $type === 'block';
+    }
+}

--- a/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ConfigElementInterface.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ConfigElementInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element;
+
+
+interface ConfigElementInterface
+{
+    /**
+     * @param string $type
+     * @return boolean
+     */
+    public function supports($type);
+
+    /**
+     * @param \SimpleXMLElement $xml
+     * @param string $type
+     * @param string $moduleName
+     * @return \SimpleXmlElement
+     */
+    public function addElementToXml(\SimpleXMLElement $xml, $type, $moduleName);
+
+    /**
+     * @param \SimpleXMLElement $xml
+     * @param string $type
+     * @param string $moduleName
+     * @return boolean
+     */
+    public function elementExistsInXml(\SimpleXMLElement $xml, $type, $moduleName);
+} 

--- a/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ControllerElement.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ControllerElement.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element;
+
+class ControllerElement implements ConfigElementInterface
+{
+    /**
+     * @param string $type
+     * @return boolean
+     */
+    public function supports($type)
+    {
+        return $type === 'controller';
+    }
+
+    /**
+     * @param \SimpleXMLElement $xml
+     * @param string $type
+     * @param string $moduleName
+     * @return \SimpleXmlElement
+     */
+    public function addElementToXml(\SimpleXMLElement $xml, $type, $moduleName)
+    {
+        $configElement = $this->getElement($xml, 'config');
+        $frontendElement = $this->getElement($configElement, 'frontend');
+        $routersElement = $this->getElement($frontendElement, 'routers');
+        $moduleElement = $this->getElement($routersElement, $this->getModuleRouteName($moduleName));
+        $moduleElement->addChild('use', 'standard');
+        $argsElement = $moduleElement->addChild('args');
+        $argsElement->addChild('module', $moduleName);
+        $argsElement->addChild('frontName', $this->getModuleRouteName($moduleName));
+    }
+
+    /**
+     * @param \SimpleXMLElement $xml
+     * @param string $type
+     * @param string $moduleName
+     * @return boolean
+     */
+    public function elementExistsInXml(\SimpleXMLElement $xml, $type, $moduleName)
+    {
+        $targetElements = $xml->xpath('/config/frontend/routers/' . $this->getModuleRouteName($moduleName));
+        return (bool) count($targetElements);
+    }
+
+    private function getElement(\SimpleXMLElement $xml, $path)
+    {
+        $elements = $xml->xpath($path);
+
+        if (!count($elements)) {
+            return $xml->addChild($path);
+        }
+
+        return $elements[0];
+    }
+
+    private function getModuleRouteName($moduleName)
+    {
+        $parts = explode('_', $moduleName);
+        return strtolower($parts[1]);
+    }
+}

--- a/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/HelperElement.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/HelperElement.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element;
+
+class HelperElement extends SimpleElementAbstract implements ConfigElementInterface
+{
+    /**
+     * @param string $type
+     * @return boolean
+     */
+    public function supports($type)
+    {
+        return $type === 'helper';
+    }
+}

--- a/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ModelElement.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ModelElement.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element;
+
+class ModelElement extends SimpleElementAbstract implements ConfigElementInterface
+{
+    /**
+     * @param string $type
+     * @return boolean
+     */
+    public function supports($type)
+    {
+        return $type === 'model';
+    }
+
+    /**
+     * @param \SimpleXMLElement $xml
+     * @param string $type
+     * @param string $moduleName
+     * @throws XmlGeneratorException
+     * @return null
+     */
+    public function addElementToXml(\SimpleXMLElement $xml, $type, $moduleName)
+    {
+        $globalElements = $xml->xpath('/config/global');
+
+        if (!count($globalElements)) {
+            throw new XmlGeneratorException('Global element not found in ' . $this->getFilePath());
+        }
+
+        $modelsElement = $this->getModelsElement($globalElements[0]);
+
+        $modelsClassContainer = $modelsElement->addChild(strtolower($moduleName));
+        $modelsClassContainer->addChild('class', $moduleName . '_' . ucfirst($type));
+
+        $resourceElementName = strtolower($moduleName).'_resource';
+        if (count($modelsElement->xpath($resourceElementName))) {
+            $modelsClassContainer->addChild('resourceModel', $resourceElementName);
+        }
+    }
+
+    private function getModelsElement(\SimpleXMLElement $xml)
+    {
+        $modelElements = $xml->xpath('models');
+
+        if (!count($modelElements)) {
+            return $xml->addChild('models');
+        }
+
+        return $modelElements[0];
+    }
+}

--- a/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ResourceModelElement.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/ResourceModelElement.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element;
+
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\XmlGeneratorException;
+
+class ResourceModelElement implements ConfigElementInterface
+{
+    /**
+     * @param string $type
+     * @return boolean
+     */
+    public function supports($type)
+    {
+        return $type === 'resource_model';
+    }
+
+    /**
+     * @param \SimpleXMLElement $xml
+     * @param string $type
+     * @return bool
+     */
+    public function elementExistsInXml(\SimpleXMLElement $xml, $type, $moduleName)
+    {
+        $targetElements = $xml->xpath('/config/global/'.$type.'s');
+        if (!count($targetElements)) {
+            return false;
+        }
+        $classElements = $xml->xpath('/config/global/'.$type.'s'.'/'.strtolower($moduleName).'_resource/class');
+        return (bool) count($classElements);
+    }
+
+    /**
+     * @param \SimpleXMLElement $xml
+     * @param string $type
+     * @param string $moduleName
+     * @throws XmlGeneratorException
+     * @return null
+     */
+    public function addElementToXml(\SimpleXMLElement $xml, $type, $moduleName)
+    {
+        $globalElements = $xml->xpath('/config/global');
+
+        if (!count($globalElements)) {
+            throw new XmlGeneratorException('Global element not found in ' . $this->getFilePath());
+        }
+
+        $modelsElement = $this->getModelsElement($globalElements[0]);
+        $modelsElement->addChild(strtolower($moduleName).'_resource')
+            ->addChild('class', $moduleName . '_Model_Resource');
+
+        $modelsClassContainers = $modelsElement->xpath(strtolower($moduleName));
+
+        if (count($modelsClassContainers) && count($modelsClassContainers[0]->xpath('class'))) {
+            $modelsClassContainers[0]->addChild('resourceModel', strtolower($moduleName).'_resource');
+        }
+    }
+
+    private function getModelsElement(\SimpleXMLElement $xml)
+    {
+        $modelElements = $xml->xpath('models');
+
+        if (!count($modelElements)) {
+            return $xml->addChild('models');
+        }
+
+        return $modelElements[0];
+    }
+}

--- a/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/SimpleElementAbstract.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/Element/SimpleElementAbstract.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\Element;
+
+
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\XmlGeneratorException;
+
+abstract class SimpleElementAbstract
+{
+    /**
+     * @param \SimpleXMLElement $xml
+     * @param string $type
+     * @return bool
+     */
+    public function elementExistsInXml(\SimpleXMLElement $xml, $type, $moduleName)
+    {
+        $targetElements = $xml->xpath('/config/global/'.$type.'s');
+        if (!count($targetElements)) {
+            return false;
+        }
+        $classElements = $xml->xpath('/config/global/'.$type.'s'.'/'.strtolower($moduleName).'/class');
+        return (bool) count($classElements);
+    }
+
+    /**
+     * @param \SimpleXMLElement $xml
+     * @param string $type
+     * @param string $moduleName
+     * @throws XmlGeneratorException
+     * @return null
+     */
+    public function addElementToXml(\SimpleXMLElement $xml, $type, $moduleName)
+    {
+        $globalElements = $xml->xpath('/config/global');
+
+        if (!count($globalElements)) {
+            throw new XmlGeneratorException('Global element not found in ' . $this->getFilePath());
+        }
+
+        $globalElements[0]->addChild($type.'s')
+            ->addChild(strtolower($moduleName))
+            ->addChild('class', $moduleName . '_' . ucfirst($type));
+    }
+} 

--- a/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/ModuleGenerator.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/ModuleGenerator.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml;
+
+use PhpSpec\Util\Filesystem;
+
+class ModuleGenerator
+{
+    /**
+     * @var Filesystem
+     */
+    private $fileSystem;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var string
+     */
+    private $codePool;
+
+    public function __construct($path, Filesystem $fileSystem, $codePool = 'local')
+    {
+        $this->fileSystem = $fileSystem;
+        $this->path = $path;
+        $this->codePool = $codePool;
+    }
+
+    public function generate($moduleName)
+    {
+        if ($this->moduleFileExists($moduleName)) {
+            return;
+        }
+
+        $values = array(
+            '%module_name%' => $moduleName,
+            '%code_pool%' => $this->codePool,
+        );
+        $this->fileSystem->putFileContents(
+            $this->getFilePath($moduleName),
+            strtr(file_get_contents(__FILE__, null, null, __COMPILER_HALT_OFFSET__), $values)
+        );
+    }
+
+    private function getFilePath($moduleName)
+    {
+        return $this->path . $moduleName . '.xml';
+    }
+
+    private function moduleFileExists($moduleName)
+    {
+        return $this->fileSystem->pathExists($this->getFilePath($moduleName));
+    }
+}
+__halt_compiler();<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <modules>
+        <%module_name%>
+            <active>true</active>
+            <codePool>%code_pool%</codePool>
+        </%module_name%>
+    </modules>
+</config>

--- a/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/XmlGeneratorException.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/Xml/XmlGeneratorException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml;
+
+
+class XmlGeneratorException extends \RuntimeException
+{
+
+} 

--- a/src/MageTest/PhpSpec/MagentoExtension/Listener/ModuleUpdateListener.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Listener/ModuleUpdateListener.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace MageTest\PhpSpec\MagentoExtension\Listener;
+
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\ConfigGenerator;
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\ModuleGenerator;
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\Xml\XmlGeneratorException;
+use MageTest\PhpSpec\MagentoExtension\Util\ClassDetector;
+use PhpSpec\Console\IO;
+use PhpSpec\Event\ExampleEvent;
+use PhpSpec\Event\SuiteEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+use PhpSpec\Exception\Fracture\ClassNotFoundException as PhpSpecClassException;
+use Prophecy\Exception\Doubler\ClassNotFoundException as ProphecyClassException;
+
+class ModuleUpdateListener implements EventSubscriberInterface
+{
+    private $classNames = array();
+    private $moduleGenerator;
+    private $configGenerator;
+    private $io;
+    private $detector;
+
+    public function __construct(
+        ModuleGenerator $moduleGenerator, ConfigGenerator $configGenerator, IO $io, ClassDetector $detector)
+    {
+        $this->moduleGenerator = $moduleGenerator;
+        $this->configGenerator = $configGenerator;
+        $this->io = $io;
+        $this->detector = $detector;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'afterExample' => array('getClassNameAfterExample', 10),
+            'afterSuite'   => array('createXmlAfterSuite', -20),
+        );
+    }
+
+    public function getClassNameAfterExample(ExampleEvent $event)
+    {
+        if (null === $exception = $event->getException()) {
+            return;
+        }
+
+        if (!($exception instanceof PhpSpecClassException) &&
+            !($exception instanceof ProphecyClassException)) {
+            return;
+        }
+
+        $className = $exception->getClassname();
+
+        if (strlen($className)) {
+            $this->classNames[$className] = $this->getModuleName($className);
+        }
+    }
+
+    public function createXmlAfterSuite(SuiteEvent $event)
+    {
+        if (!$this->io->isCodeGenerationEnabled()) {
+            return;
+        }
+
+        foreach ($this->classNames as $className => $moduleName) {
+            if (!$this->detector->classExists($className)) {
+                continue;
+            }
+
+            $this->moduleGenerator->generate(($moduleName));
+
+            $this->configGenerator->generateElement(
+                $this->getClassType($className),
+                $moduleName
+            );
+        }
+    }
+
+    private function getModuleName($className)
+    {
+        $parts = explode('_', $className);
+        if (!isset($parts[0]) || !isset($parts[1])) {
+            throw new XmlGeneratorException('Could not determine a module name from ' . $className);
+        }
+        return $parts[0] . '_' . $parts[1];
+    }
+
+    private function getClassType($className)
+    {
+        $parts = explode('_', $className);
+        if (!isset($parts[2])) {
+            throw new XmlGeneratorException('Could not determine an object type from ' . $className);
+        }
+        if ($parts[2] === 'Model' && $parts[3] === 'Resource') {
+            return 'resource_model';
+        }
+        if ($this->partIsController($parts[count($parts)-1])) {
+            return 'controller';
+        }
+        return strtolower($parts[2]);
+    }
+
+    private function partIsController($part)
+    {
+        $element = 'Controller';
+        return strlen($part) - strlen($element) === strrpos($part, $element);
+    }
+}

--- a/src/MageTest/PhpSpec/MagentoExtension/Util/ClassDetector.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Util/ClassDetector.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace MageTest\PhpSpec\MagentoExtension\Util;
+
+
+class ClassDetector
+{
+    public function classExists($className)
+    {
+        return class_exists($className);
+    }
+} 


### PR DESCRIPTION
Generates the module and config XML when objects are created from specs. Once the config XML file exists it is modified as more objects are created.

Supports:
- Models
- Resource models
- Blocks
- Helpers
- Controllers
