### PR TITLE
Fix issue with describing a controller not generating correct spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ $ bin/phpspec describe:block 'vendorname_modulename/blockname'
 $ bin/phpspec describe:helper 'vendorname_modulename/helpername'
 ```
 
+### Describing a controller
+
+```bash
+$ bin/phpspec describe:controller 'vendorname_modulename/helpername'
+```
+
 ## Issue Submission
 
 Make sure you've read the [issue submission guidelines](https://github.com/MageTest/MageSpec/blob/develop/contributing.md#issue-submission) before you open a [new issue](https://github.com/MageTest/MageSpec/blob/develop/issues/new).

--- a/features/bootstrap/templates/specs/default.template
+++ b/features/bootstrap/templates/specs/default.template
@@ -2,6 +2,7 @@
 
 namespace spec;
 
+use %class_name%;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -9,6 +10,6 @@ class %class_name%Spec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('%class_name%');
+        $this->shouldHaveType(%class_name%::class);
     }
 }

--- a/features/bootstrap/templates/specs/non_magento.template
+++ b/features/bootstrap/templates/specs/non_magento.template
@@ -2,6 +2,7 @@
 
 namespace spec\Behat;
 
+use Behat\Test;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -9,6 +10,6 @@ class TestSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Behat\Test');
+        $this->shouldHaveType(Test::class);
     }
 }

--- a/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/ControllerSpecificationGenerator.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/ControllerSpecificationGenerator.php
@@ -8,6 +8,8 @@ use PhpSpec\Locator\Resource as ResourceInterface;
 
 class ControllerSpecificationGenerator extends PromptingGenerator implements GeneratorInterface
 {
+    const SUPPORTED_GENERATOR = 'controller_specification';
+
     /**
      * @param ResourceInterface $resource
      * @param string $generation
@@ -16,7 +18,7 @@ class ControllerSpecificationGenerator extends PromptingGenerator implements Gen
      */
     public function supports(ResourceInterface $resource, $generation, array $data)
     {
-        return 'controller_specification' === $generation;
+        return self::SUPPORTED_GENERATOR === $generation;
     }
 
     public function getPriority()
@@ -49,7 +51,7 @@ class ControllerSpecificationGenerator extends PromptingGenerator implements Gen
             '%subject%'   => $resource->getSrcClassname()
         );
 
-        if (!$content = $this->getTemplateRenderer()->render('controller_specification', $values)) {
+        if (!$content = $this->getTemplateRenderer()->render(self::SUPPORTED_GENERATOR, $values)) {
             $content = $this->getTemplateRenderer()->renderString(
                 file_get_contents(__DIR__ . '/templates/controller_spec.template'), $values
             );
@@ -66,7 +68,7 @@ class ControllerSpecificationGenerator extends PromptingGenerator implements Gen
      */
     protected function getGeneratedMessage(ResourceInterface $resource, $filepath)
     {
-        sprintf(
+        return sprintf(
             "<info>ControllerSpecification for <value>%s</value> created in <value>'%s'</value>.</info>\n",
             $resource->getSrcClassname(),
             $filepath

--- a/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeControllerCommand.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Console/Command/DescribeControllerCommand.php
@@ -33,6 +33,8 @@ use Symfony\Component\Console\Input\InputArgument;
  */
 class DescribeControllerCommand extends MageCommand
 {
+    const TYPE = 'controller';
+
     /**
      * @var string
      */
@@ -55,7 +57,7 @@ HELP;
     /**
      * @var string
      */
-    protected $type = 'controller';
+    protected $type = self::TYPE;
 
     protected function configure()
     {

--- a/src/MageTest/PhpSpec/MagentoExtension/Console/Command/MageCommand.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Console/Command/MageCommand.php
@@ -21,6 +21,7 @@
  */
 namespace MageTest\PhpSpec\MagentoExtension\Console\Command;
 
+use MageTest\PhpSpec\MagentoExtension\CodeGenerator\Generator\ControllerSpecificationGenerator;
 use PhpSpec\Locator\ResourceManagerInterface;
 use PhpSpec\ServiceContainer;
 use Symfony\Component\Console\Command\Command;
@@ -69,6 +70,9 @@ abstract class MageCommand extends Command
         $classname = $this->type . ':' . $alias;
         $resource  = $this->container->get('locator.resource_manager')->createResource($classname);
 
-        $this->container->get('code_generator')->generate($resource, 'specification');
+        $this->container->get('code_generator')->generate(
+            $resource,
+            $this->type == DescribeControllerCommand::TYPE ? ControllerSpecificationGenerator::SUPPORTED_GENERATOR : 'specification'
+        );
     }
 } 


### PR DESCRIPTION
- [X] Feature tests now check the content of the generated files rather than checking if they exist or not
- [X] Controller specification now uses our custom template: https://github.com/MageTest/MageSpec/blob/develop/src/MageTest/PhpSpec/MagentoExtension/CodeGenerator/Generator/templates/controller_spec.template

To test run `bin/phpspec describe:controller 'magespec_reviews/product'` followed by: `bin/phpspec run` and this error will be thrown:
```Magespec_Reviews_ProductController
  11  ! is initializable
        exception [err:ArgumentCountError("Too few arguments to function Mage_Core_Controller_Varien_Action::__construct(), 0 passed and at least 2 expected")] has been thrown.```

