### PR TITLE
Fix issue with phpspec bootstrapping not working

### DIFF
--- a/spec/MageTest/PhpSpec/MagentoExtension/ExtensionSpec.php
+++ b/spec/MageTest/PhpSpec/MagentoExtension/ExtensionSpec.php
@@ -21,7 +21,7 @@
  */
 namespace spec\MageTest\PhpSpec\MagentoExtension;
 
-use MageTest\PhpSpec\MagentoExtension\Listener\BootstrapListener;
+use MageTest\PhpSpec\MagentoExtension\Listener\RegisterAutoloaderListener;
 use PhpSpec\ObjectBehavior;
 use PhpSpec\Process\Context\ExecutionContext;
 use PhpSpec\ServiceContainer;
@@ -170,7 +170,7 @@ class ExtensionSpec extends ObjectBehavior
 
     function it_adds_event_dispatcher_when_loaded($container)
     {
-        $container->define('event_dispatcher.listeners.bootstrap', $this->service(BootstrapListener::class, $container), ['event_dispatcher.listeners'])->shouldBeCalled();
+        $container->define('event_dispatcher.listeners.register_autoloader', $this->service(RegisterAutoloaderListener::class, $container), ['event_dispatcher.listeners'])->shouldBeCalled();
 
         $this->load($container);
     }

--- a/src/MageTest/PhpSpec/MagentoExtension/Extension.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Extension.php
@@ -103,8 +103,8 @@ class Extension implements PhpspecExtension
 
     private function setEvents(ServiceContainer $container, MageLocator $configuration)
     {
-        $container->define('event_dispatcher.listeners.bootstrap', function () use ($configuration) {
-            return new Listener\BootstrapListener($configuration);
+        $container->define('event_dispatcher.listeners.register_autoloader', function () use ($configuration) {
+            return new Listener\RegisterAutoloaderListener($configuration);
         }, ['event_dispatcher.listeners']);
 
         $container->define('event_dispatcher.listeners.module_update', function ($c) {

--- a/src/MageTest/PhpSpec/MagentoExtension/Listener/RegisterAutoloaderListener.php
+++ b/src/MageTest/PhpSpec/MagentoExtension/Listener/RegisterAutoloaderListener.php
@@ -6,7 +6,7 @@ use MageTest\PhpSpec\MagentoExtension\Autoloader\MageLoader;
 use MageTest\PhpSpec\MagentoExtension\Configuration\MageLocator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class BootstrapListener implements EventSubscriberInterface
+class RegisterAutoloaderListener implements EventSubscriberInterface
 {
     private $configuration;
 


### PR DESCRIPTION
We were defining the same service name which was causing the phpspec
bootstrap listener to not execute

Renamed the bootstrap listener to something more meaningful